### PR TITLE
Update whatsapp.sh

### DIFF
--- a/fragments/labels/whatsapp.sh
+++ b/fragments/labels/whatsapp.sh
@@ -1,6 +1,7 @@
 whatsapp)
     name="WhatsApp"
     type="dmg"
-    downloadURL="https://web.whatsapp.com/desktop/mac/files/WhatsApp.dmg"
+    downloadURL="https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release"
     expectedTeamID="57T9237FN3"
+    appNewVersion=$(curl -s https://web.whatsapp.com/desktop/mac/releases | awk -F '"' '/"name"/ {print $4}')
     ;;


### PR DESCRIPTION
Updated WhatsApp cause of new version and new downloadURL. 
Provided AppNewVersion Paramter to check the local against the new App Version.

Debug Output:
2023-11-30 17:18:00 : REQ   : whatsapp : ################## Start Installomator v. 10.6beta, date 2023-11-30
2023-11-30 17:18:00 : INFO  : whatsapp : ################## Version: 10.6beta
2023-11-30 17:18:00 : INFO  : whatsapp : ################## Date: 2023-11-30
2023-11-30 17:18:00 : INFO  : whatsapp : ################## whatsapp
2023-11-30 17:18:00 : DEBUG : whatsapp : DEBUG mode 1 enabled.
2023-11-30 17:18:00 : DEBUG : whatsapp : name=WhatsApp
2023-11-30 17:18:00 : DEBUG : whatsapp : appName=
2023-11-30 17:18:00 : DEBUG : whatsapp : type=dmg
2023-11-30 17:18:00 : DEBUG : whatsapp : archiveName=
2023-11-30 17:18:00 : DEBUG : whatsapp : downloadURL=https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release
2023-11-30 17:18:00 : DEBUG : whatsapp : curlOptions=
2023-11-30 17:18:00 : DEBUG : whatsapp : appNewVersion=2.2349.51
2023-11-30 17:18:00 : DEBUG : whatsapp : appCustomVersion function: Not defined
2023-11-30 17:18:00 : DEBUG : whatsapp : versionKey=CFBundleShortVersionString
2023-11-30 17:18:00 : DEBUG : whatsapp : packageID=
2023-11-30 17:18:00 : DEBUG : whatsapp : pkgName=
2023-11-30 17:18:00 : DEBUG : whatsapp : choiceChangesXML=
2023-11-30 17:18:00 : DEBUG : whatsapp : expectedTeamID=57T9237FN3
2023-11-30 17:18:00 : DEBUG : whatsapp : blockingProcesses=
2023-11-30 17:18:00 : DEBUG : whatsapp : installerTool=
2023-11-30 17:18:00 : DEBUG : whatsapp : CLIInstaller=
2023-11-30 17:18:00 : DEBUG : whatsapp : CLIArguments=
2023-11-30 17:18:00 : DEBUG : whatsapp : updateTool=
2023-11-30 17:18:00 : DEBUG : whatsapp : updateToolArguments=
2023-11-30 17:18:00 : DEBUG : whatsapp : updateToolRunAsCurrentUser=
2023-11-30 17:18:00 : INFO  : whatsapp : BLOCKING_PROCESS_ACTION=tell_user
2023-11-30 17:18:00 : INFO  : whatsapp : NOTIFY=success
2023-11-30 17:18:00 : INFO  : whatsapp : LOGGING=DEBUG
2023-11-30 17:18:00 : INFO  : whatsapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-30 17:18:00 : INFO  : whatsapp : Label type: dmg
2023-11-30 17:18:00 : INFO  : whatsapp : archiveName: WhatsApp.dmg
2023-11-30 17:18:00 : INFO  : whatsapp : no blocking processes defined, using WhatsApp as default
2023-11-30 17:18:00 : DEBUG : whatsapp : Changing directory to /Users/b.kollmer/Development/Installomator/Installomator/build
2023-11-30 17:18:00 : INFO  : whatsapp : name: WhatsApp, appName: WhatsApp.app
2023-11-30 17:18:00.713 mdfind[22830:11350311] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-11-30 17:18:00.713 mdfind[22830:11350311] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-11-30 17:18:00.855 mdfind[22830:11350311] Couldn't determine the mapping between prefab keywords and predicates.
2023-11-30 17:18:00 : WARN  : whatsapp : No previous app found
2023-11-30 17:18:00 : WARN  : whatsapp : could not find WhatsApp.app
2023-11-30 17:18:00 : INFO  : whatsapp : appversion:
2023-11-30 17:18:00 : INFO  : whatsapp : Latest version of WhatsApp is 2.2349.51
2023-11-30 17:18:00 : REQ   : whatsapp : Downloading https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release to WhatsApp.dmg
2023-11-30 17:18:00 : DEBUG : whatsapp : No Dialog connection, just download
2023-11-30 17:20:01 : DEBUG : whatsapp : File list: -rw-r--r--  1 root  staff   103M 30 Nov 17:20 WhatsApp.dmg
2023-11-30 17:20:01 : DEBUG : whatsapp : File type: WhatsApp.dmg: zlib compressed data
2023-11-30 17:20:01 : DEBUG : whatsapp : curl output was:
*   Trying [2a03:2880:f276:cd:face:b00c:0:167]:443...
* Connected to web.whatsapp.com (2a03:2880:f276:cd:face:b00c:0:167) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2846 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=Menlo Park; O=Meta Platforms, Inc.; CN=*.whatsapp.net
*  start date: Sep  8 00:00:00 2023 GMT
*  expire date: Dec  7 23:59:59 2023 GMT
*  subjectAltName: host "web.whatsapp.com" matched cert's "*.whatsapp.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: web.whatsapp.com]
* h2 [:path: /desktop/mac_native/release/?configuration=Release]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x134814200)
> GET /desktop/mac_native/release/?configuration=Release HTTP/2
> Host: web.whatsapp.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 302
< vary: Accept-Encoding
< location: https://scontent-fra3-1.xx.fbcdn.net/v/t39.16592-6/10000000_748667177299829_6406801816908820547_n.dmg/WhatsApp-2.23.23.82.dmg?_nc_cat=105&ccb=1-7&_nc_sid=8f3826&_nc_ohc=Ukjw49fqALEAX8fFCoC&_nc_ht=scontent-fra3-1.xx&oh=00_AfDeKhEFVIukrBBpEmFRYMG2er9Aie2eyO4mkBaA1GGC8Q&oe=656CE77E < reporting-endpoints:
< document-policy: force-load-at-top
< permissions-policy-report-only: autoplay=(), clipboard-read=(), clipboard-write=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), gamepad=(), keyboard-map=(), otp-credentials=(), picture-in-picture=(), xr-spatial-tracking=() < permissions-policy: accelerometer=(), ambient-light-sensor=(), bluetooth=(), camera=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), window-management=() < cross-origin-resource-policy: same-origin
< cross-origin-opener-policy: same-origin-allow-popups < pragma: no-cache
< cache-control: private, no-cache, no-store, must-revalidate < expires: Sat, 01 Jan 2000 00:00:00 GMT
< x-content-type-options: nosniff
< x-xss-protection: 0
< content-security-policy: frame-ancestors 'self'; < content-security-policy: default-src 'self' data: blob:;script-src 'self' data: blob: 'unsafe-eval' 'unsafe-inline' https://static.whatsapp.net https://ajax.googleapis.com https://api.search.live.net https://maps.googleapis.com https://www.youtube.com https://s.ytimg.com;style-src 'self' data: blob: 'unsafe-inline' https://fonts.googleapis.com;connect-src 'self' data: blob: https://*.whatsapp.net https://www.facebook.com https://*.giphy.com https://*.tenor.co https://crashlogs.whatsapp.net/wa_clb_data https://crashlogs.whatsapp.net/wa_fls_upload_check https://www.bingapis.com/api/v6/images/search https://*.google-analytics.com wss://*.web.whatsapp.com wss://web.whatsapp.com https://www.whatsapp.com https://dyn.web.whatsapp.com https://graph.whatsapp.com/graphql/;font-src data: 'self' https://fonts.googleapis.com https://fonts.gstatic.com;img-src 'self' data: blob: *;media-src 'self' data: blob: https://*.whatsapp.net https://*.giphy.com https://*.tenor.co https://*.cdninstagram.com https://*.streamable.com https://*.sharechat.com https://*.fbcdn.net mediastream:;child-src 'self' data: blob:;frame-src 'self' data: blob: https://www.youtube.com;block-all-mixed-content;upgrade-insecure-requests; < strict-transport-security: max-age=31536000; preload; includeSubDomains < content-type: text/html; charset="utf-8"
< x-fb-debug: BePS68N8M1/+0/u5IKtxEPMLwIe+ywF9ARjMGwavQl3SMSiTBS6GKeDY11J9rwZH3eGk0ot1zsfwnib5C9cdSw== < content-length: 0
< date: Thu, 30 Nov 2023 16:18:01 GMT
< alt-svc: h3=":443"; ma=86400
<
{ [0 bytes data]
* Connection #0 to host web.whatsapp.com left intact
* Issue another request to this URL: 'https://scontent-fra3-1.xx.fbcdn.net/v/t39.16592-6/10000000_748667177299829_6406801816908820547_n.dmg/WhatsApp-2.23.23.82.dmg?_nc_cat=105&ccb=1-7&_nc_sid=8f3826&_nc_ohc=Ukjw49fqALEAX8fFCoC&_nc_ht=scontent-fra3-1.xx&oh=00_AfDeKhEFVIukrBBpEmFRYMG2er9Aie2eyO4mkBaA1GGC8Q&oe=656CE77E'
*   Trying [2a03:2880:f084:d:face:b00c:0:3]:443...
* Connected to scontent-fra3-1.xx.fbcdn.net (2a03:2880:f084:d:face:b00c:0:3) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [333 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2914 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=Menlo Park; O=Meta Platforms, Inc.; CN=*.facebook.com
*  start date: Sep  8 00:00:00 2023 GMT
*  expire date: Dec  7 23:59:59 2023 GMT
*  subjectAltName: host "scontent-fra3-1.xx.fbcdn.net" matched cert's "*.xx.fbcdn.net"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: scontent-fra3-1.xx.fbcdn.net]
* h2 [:path: /v/t39.16592-6/10000000_748667177299829_6406801816908820547_n.dmg/WhatsApp-2.23.23.82.dmg?_nc_cat=105&ccb=1-7&_nc_sid=8f3826&_nc_ohc=Ukjw49fqALEAX8fFCoC&_nc_ht=scontent-fra3-1.xx&oh=00_AfDeKhEFVIukrBBpEmFRYMG2er9Aie2eyO4mkBaA1GGC8Q&oe=656CE77E]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x134814200)
> GET /v/t39.16592-6/10000000_748667177299829_6406801816908820547_n.dmg/WhatsApp-2.23.23.82.dmg?_nc_cat=105&ccb=1-7&_nc_sid=8f3826&_nc_ohc=Ukjw49fqALEAX8fFCoC&_nc_ht=scontent-fra3-1.xx&oh=00_AfDeKhEFVIukrBBpEmFRYMG2er9Aie2eyO4mkBaA1GGC8Q&oe=656CE77E HTTP/2
> Host: scontent-fra3-1.xx.fbcdn.net
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< x-storage-error-category: dfs:none;sc_p:206:WSE_NOT_SET < last-modified: Thu, 16 Nov 2023 20:57:00 GMT
< content-type: application/octet-stream
< thrift_fmhk: GBASQI30saKdHuq181mEV+aPFfDr4Z0EAA== < timing-allow-origin: *
< cross-origin-resource-policy: cross-origin
< access-control-allow-origin: *
< cache-control: max-age=1209600, no-transform
< accept-ranges: bytes
< content-length: 107937864
< date: Thu, 30 Nov 2023 16:18:01 GMT
< alt-svc: h3=":443"; ma=86400
<
{ [1492 bytes data]
* received GOAWAY, error=0, last_stream=1 { [16367 bytes data]
* Closing connection 1

2023-11-30 17:20:01 : DEBUG : whatsapp : DEBUG mode 1, not checking for blocking processes
2023-11-30 17:20:01 : REQ   : whatsapp : Installing WhatsApp
2023-11-30 17:20:01 : INFO  : whatsapp : Mounting /Users/b.kollmer/Development/Installomator/Installomator/build/WhatsApp.dmg
2023-11-30 17:20:05 : DEBUG : whatsapp : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $15FC81A0
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $326C9079
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $BB02F430
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $02C65149
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $BB02F430
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $77E71BF4
Die überprüfte CRC32-Prüfsumme ist $E366A12A
/dev/disk6              GUID_partition_scheme
/dev/disk6s1            Apple_HFS                       /Volumes/WhatsApp Installer 1

2023-11-30 17:20:05 : INFO  : whatsapp : Mounted: /Volumes/WhatsApp Installer 1 2023-11-30 17:20:05 : INFO  : whatsapp : Verifying: /Volumes/WhatsApp Installer 1/WhatsApp.app 2023-11-30 17:20:05 : DEBUG : whatsapp : App size: 331M /Volumes/WhatsApp Installer 1/WhatsApp.app 2023-11-30 17:20:07 : DEBUG : whatsapp : Debugging enabled, App Verification output was: /Volumes/WhatsApp Installer 1/WhatsApp.app: accepted source=Notarized Developer ID
origin=Developer ID Application: WhatsApp Inc. (57T9237FN3)

2023-11-30 17:20:07 : INFO  : whatsapp : Team ID matching: 57T9237FN3 (expected: 57T9237FN3 ) 2023-11-30 17:20:07 : INFO  : whatsapp : Installing WhatsApp version 23.23.82 on versionKey CFBundleShortVersionString. 2023-11-30 17:20:07 : INFO  : whatsapp : App has LSMinimumSystemVersion: 11.0 2023-11-30 17:20:07 : DEBUG : whatsapp : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-11-30 17:20:07 : INFO  : whatsapp : Finishing... 2023-11-30 17:20:11 : INFO  : whatsapp : name: WhatsApp, appName: WhatsApp.app 2023-11-30 17:20:11.034 mdfind[23952:11358397] [UserQueryParser] Loading keywords and predicates for locale "de_DE" 2023-11-30 17:20:11.035 mdfind[23952:11358397] [UserQueryParser] Loading keywords and predicates for locale "de" 2023-11-30 17:20:11.100 mdfind[23952:11358397] Couldn't determine the mapping between prefab keywords and predicates. 2023-11-30 17:20:11 : WARN  : whatsapp : No previous app found 2023-11-30 17:20:11 : WARN  : whatsapp : could not find WhatsApp.app
2023-11-30 17:20:11 : REQ   : whatsapp : Installed WhatsApp, version 23.23.82
2023-11-30 17:20:11 : INFO  : whatsapp : notifying
2023-11-30 17:20:11 : DEBUG : whatsapp : Unmounting /Volumes/WhatsApp Installer 1
2023-11-30 17:20:11 : DEBUG : whatsapp : Debugging enabled, Unmounting output was:
"disk6" ejected.
2023-11-30 17:20:11 : DEBUG : whatsapp : DEBUG mode 1, not reopening anything
2023-11-30 17:20:11 : REQ   : whatsapp : All done!
2023-11-30 17:20:11 : REQ   : whatsapp : ################## End Installomator, exit code 0