### PR TITLE
Create vectorworks2023sp8.sh

### DIFF
--- a/fragments/labels/vectorworks2023sp8.sh
+++ b/fragments/labels/vectorworks2023sp8.sh
@@ -1,0 +1,8 @@
+vectorworks2023sp8)
+    name="Vectorworks 2023 SP8"
+    appName="Vectorworks 2023 installieren.app"
+    type="dmg"
+    packageID="net.vectorworks.2023.vectorworksinstaller"
+    downloadURL="https://server3-d.vectorworks-online.de/cw/vw2023/mac/Vectorworks%202023%20SP8.dmg"
+    expectedTeamID="LFNG3Q6WX2"
+    ;;


### PR DESCRIPTION
2024-01-15 12:25:05 : REQ   : vectorworks2023sp8 : ################## Start Installomator v. 10.6beta, date 2024-01-15
2024-01-15 12:25:05 : INFO  : vectorworks2023sp8 : ################## Version: 10.6beta
2024-01-15 12:25:05 : INFO  : vectorworks2023sp8 : ################## Date: 2024-01-15
2024-01-15 12:25:05 : INFO  : vectorworks2023sp8 : ################## vectorworks2023sp8
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : DEBUG mode 1 enabled.
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : name=Vectorworks 2023 SP8
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : appName=Vectorworks 2023 installieren.app
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : type=dmg
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : archiveName=
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : downloadURL=https://server3-d.vectorworks-online.de/cw/vw2023/mac/Vectorworks%202023%20SP8.dmg
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : curlOptions=
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : appNewVersion=
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : appCustomVersion function: Not defined
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : versionKey=CFBundleShortVersionString
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : packageID=net.vectorworks.2023.vectorworksinstaller
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : pkgName=
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : choiceChangesXML=
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : expectedTeamID=LFNG3Q6WX2
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : blockingProcesses=
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : installerTool=
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : CLIInstaller=
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : CLIArguments=
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : updateTool=
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : updateToolArguments=
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : updateToolRunAsCurrentUser=
2024-01-15 12:25:05 : INFO  : vectorworks2023sp8 : BLOCKING_PROCESS_ACTION=tell_user
2024-01-15 12:25:05 : INFO  : vectorworks2023sp8 : NOTIFY=success
2024-01-15 12:25:05 : INFO  : vectorworks2023sp8 : LOGGING=DEBUG
2024-01-15 12:25:05 : INFO  : vectorworks2023sp8 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-15 12:25:05 : INFO  : vectorworks2023sp8 : Label type: dmg
2024-01-15 12:25:05 : INFO  : vectorworks2023sp8 : archiveName: Vectorworks 2023 SP8.dmg
2024-01-15 12:25:05 : INFO  : vectorworks2023sp8 : no blocking processes defined, using Vectorworks 2023 SP8 as default
2024-01-15 12:25:05 : DEBUG : vectorworks2023sp8 : Changing directory to /Users/b.kollmer/Development/Installomator/Installomator/build
2024-01-15 12:25:05 : INFO  : vectorworks2023sp8 : No version found using packageID net.vectorworks.2023.vectorworksinstaller
2024-01-15 12:25:05 : INFO  : vectorworks2023sp8 : name: Vectorworks 2023 SP8, appName: Vectorworks 2023 installieren.app
2024-01-15 12:25:05.774 mdfind[84409:14176680] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2024-01-15 12:25:05.775 mdfind[84409:14176680] [UserQueryParser] Loading keywords and predicates for locale "de"
 2024-01-15 12:25:05.972 mdfind[84409:14176680] Couldn't determine the mapping between prefab keywords and predicates.
2024-01-15 12:25:06 : WARN  : vectorworks2023sp8 : No previous app found
2024-01-15 12:25:06 : WARN  : vectorworks2023sp8 : could not find Vectorworks 2023 installieren.app
2024-01-15 12:25:06 : INFO  : vectorworks2023sp8 : appversion:
2024-01-15 12:25:06 : INFO  : vectorworks2023sp8 : Latest version not specified.
2024-01-15 12:25:06 : REQ   : vectorworks2023sp8 : Downloading https://server3-d.vectorworks-online.de/cw/vw2023/mac/Vectorworks%202023%20SP8.dmg to Vectorworks 2023 SP8.dmg
2024-01-15 12:25:06 : DEBUG : vectorworks2023sp8 : No Dialog connection, just download
2024-01-15 12:31:56 : DEBUG : vectorworks2023sp8 : File list: -rw-r--r--@ 1 root  staff   8,4G 15 Jan 12:31 Vectorworks 2023 SP8.dmg
2024-01-15 12:31:56 : DEBUG : vectorworks2023sp8 : File type: Vectorworks 2023 SP8.dmg: Apple Driver Map, blocksize 512, blockcount 23013376, devtype 0, devid 0, driver count 0, contains[@0x200]: Apple Partition Map, map block count 2, start block 1, block count 63, name Apple, type Apple_partition_map, valid, allocated, contains[@0x400]: Apple Partition Map, map block count 2, start block 64, block count 23013312, name disk image, type Apple_HFS, valid, allocated, readable, writable, mount at startup
2024-01-15 12:31:56 : DEBUG : vectorworks2023sp8 : curl output was:
*   Trying 46.4.85.150:443...
* Connected to server3-d.vectorworks-online.de (46.4.85.150) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [336 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2779 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=*.vectorworks-online.de
*  start date: May 23 00:00:00 2023 GMT
*  expire date: May 22 23:59:59 2024 GMT
*  subjectAltName: host "server3-d.vectorworks-online.de" matched cert's "*.vectorworks-online.de"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=Thawte TLS RSA CA G1
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /cw/vw2023/mac/Vectorworks%202023%20SP8.dmg HTTP/1.1
> Host: server3-d.vectorworks-online.de
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Server: nginx/1.18.0 (Ubuntu)
< Date: Mon, 15 Jan 2024 11:25:06 GMT
< Content-Type: application/octet-stream
< Content-Length: 8987114635
< Last-Modified: Fri, 15 Dec 2023 17:53:18 GMT
< Connection: keep-alive
< ETag: "657c928e-217ac7c8b"
< Accept-Ranges: bytes
<
{ [16109 bytes data]
* Connection #0 to host server3-d.vectorworks-online.de left intact

2024-01-15 12:31:56 : DEBUG : vectorworks2023sp8 : DEBUG mode 1, not checking for blocking processes
2024-01-15 12:31:56 : REQ   : vectorworks2023sp8 : Installing Vectorworks 2023 SP8
2024-01-15 12:31:56 : INFO  : vectorworks2023sp8 : Mounting /Users/b.kollmer/Development/Installomator/Installomator/build/Vectorworks 2023 SP8.dmg
2024-01-15 12:32:01 : DEBUG : vectorworks2023sp8 : Debugging enabled, dmgmount output was:
Prüfsumme für Driver Descriptor Map (DDM : 0) berechnen …
Driver Descriptor Map (DDM : 0): Die überprüfte CRC32-Prüfsumme ist $9EF176A3
Prüfsumme für Apple (Apple_partition_map : 1) berechnen …
Apple (Apple_partition_map : 1): Die überprüfte CRC32-Prüfsumme ist $B7C23296
Prüfsumme für disk image (Apple_HFS : 2) berechnen …
disk image (Apple_HFS : 2): Die überprüfte CRC32-Prüfsumme ist $E3112349
Die überprüfte CRC32-Prüfsumme ist $68CAE8F9
/dev/disk5              Apple_partition_scheme
/dev/disk5s1            Apple_partition_map
/dev/disk5s2            Apple_HFS                       /Volumes/Vectorworks

2024-01-15 12:32:01 : INFO  : vectorworks2023sp8 : Mounted: /Volumes/Vectorworks 2024-01-15 12:32:01 : INFO  : vectorworks2023sp8 : Verifying: /Volumes/Vectorworks/Vectorworks 2023 installieren.app
2024-01-15 12:32:01 : DEBUG : vectorworks2023sp8 : App size: 8,3G       /Volumes/Vectorworks/Vectorworks 2023 installieren.app
2024-01-15 12:32:11 : DEBUG : vectorworks2023sp8 : Debugging enabled, App Verification output was:
/Volumes/Vectorworks/Vectorworks 2023 installieren.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Vectorworks, Inc. (LFNG3Q6WX2)

2024-01-15 12:32:11 : INFO  : vectorworks2023sp8 : Team ID matching: LFNG3Q6WX2 (expected: LFNG3Q6WX2 ) 2024-01-15 12:32:11 : INFO  : vectorworks2023sp8 : Installing Vectorworks 2023 SP8 version 28.0.8 on versionKey CFBundleShortVersionString. 2024-01-15 12:32:11 : INFO  : vectorworks2023sp8 : App has LSMinimumSystemVersion: 10.10.0 2024-01-15 12:32:11 : DEBUG : vectorworks2023sp8 : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2024-01-15 12:32:11 : INFO  : vectorworks2023sp8 : Finishing... 2024-01-15 12:32:14 : INFO  : vectorworks2023sp8 : No version found using packageID net.vectorworks.2023.vectorworksinstaller 2024-01-15 12:32:14 : INFO  : vectorworks2023sp8 : name: Vectorworks 2023 SP8, appName: Vectorworks 2023 installieren.app 2024-01-15 12:32:14.814 mdfind[84991:14192938] [UserQueryParser] Loading keywords and predicates for locale "de_DE" 2024-01-15 12:32:14.814 mdfind[84991:14192938] [UserQueryParser] Loading keywords and predicates for locale "de" 2024-01-15 12:32:15.020 mdfind[84991:14192938] Couldn't determine the mapping between prefab keywords and predicates. 2024-01-15 12:32:15 : WARN  : vectorworks2023sp8 : No previous app found 2024-01-15 12:32:15 : WARN  : vectorworks2023sp8 : could not find Vectorworks 2023 installieren.app
2024-01-15 12:32:15 : REQ   : vectorworks2023sp8 : Installed Vectorworks 2023 SP8, version 28.0.8
2024-01-15 12:32:15 : INFO  : vectorworks2023sp8 : notifying
2024-01-15 12:32:15 : DEBUG : vectorworks2023sp8 : Unmounting /Volumes/Vectorworks
2024-01-15 12:32:15 : DEBUG : vectorworks2023sp8 : Debugging enabled, Unmounting output was:
"disk5" ejected.
2024-01-15 12:32:15 : DEBUG : vectorworks2023sp8 : DEBUG mode 1, not reopening anything
2024-01-15 12:32:15 : REQ   : vectorworks2023sp8 : All done!
2024-01-15 12:32:15 : REQ   : vectorworks2023sp8 : ################## End Installomator, exit code 0