### PR TITLE
Create splashtopstreamer.sh

### DIFF
--- a/fragments/labels/splashtopstreamer.sh
+++ b/fragments/labels/splashtopstreamer.sh
@@ -1,0 +1,7 @@
+splashtopstreamer)
+    name="Splashtop Streamer"
+    type="pkgInDmg"
+    downloadURL=$(curl -fsLI "https://my.splashtop.com/csrs/mac" | grep -i '^location:' | tail -n 1 | cut -d ' ' -f 2 | tr -d '\r')
+    appNewVersion=$(echo $downloadURL | sed -E 's/.*_v([0-9.]+).dmg/\1/')
+    expectedTeamID="CPQQ3AW49Y"
+    ;;


### PR DESCRIPTION
2024-01-24 16:17:36 : REQ   : splashtopstreamer : ################## Start Installomator v. 10.6beta, date 2024-01-24
2024-01-24 16:17:36 : INFO  : splashtopstreamer : ################## Version: 10.6beta
2024-01-24 16:17:36 : INFO  : splashtopstreamer : ################## Date: 2024-01-24
2024-01-24 16:17:36 : INFO  : splashtopstreamer : ################## splashtopstreamer
2024-01-24 16:17:36 : DEBUG : splashtopstreamer : DEBUG mode 1 enabled.
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : name=Splashtop Streamer
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : appName=
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : type=pkgInDmg
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : archiveName=
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : downloadURL=https://download.splashtop.com/csrs/Splashtop_Streamer_Mac_DEPLOY_INSTALLER_v3.6.2.1.dmg
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : curlOptions=
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : appNewVersion=3.6.2.1
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : appCustomVersion function: Not defined
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : versionKey=CFBundleShortVersionString
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : packageID=
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : pkgName=
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : choiceChangesXML=
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : expectedTeamID=CPQQ3AW49Y
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : blockingProcesses=
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : installerTool=
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : CLIInstaller=
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : CLIArguments=
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : updateTool=
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : updateToolArguments=
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : updateToolRunAsCurrentUser=
2024-01-24 16:17:37 : INFO  : splashtopstreamer : BLOCKING_PROCESS_ACTION=tell_user
2024-01-24 16:17:37 : INFO  : splashtopstreamer : NOTIFY=success
2024-01-24 16:17:37 : INFO  : splashtopstreamer : LOGGING=DEBUG
2024-01-24 16:17:37 : INFO  : splashtopstreamer : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-24 16:17:37 : INFO  : splashtopstreamer : Label type: pkgInDmg
2024-01-24 16:17:37 : INFO  : splashtopstreamer : archiveName: Splashtop Streamer.dmg
2024-01-24 16:17:37 : INFO  : splashtopstreamer : no blocking processes defined, using Splashtop Streamer as default
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : Changing directory to /Users/b.kollmer/Development/Installomator/Installomator/build
2024-01-24 16:17:37 : INFO  : splashtopstreamer : App(s) found: /Applications/Splashtop Streamer.app
2024-01-24 16:17:37 : INFO  : splashtopstreamer : found app at /Applications/Splashtop Streamer.app, version 3.6.2.1, on versionKey CFBundleShortVersionString
2024-01-24 16:17:37 : INFO  : splashtopstreamer : appversion: 3.6.2.1
2024-01-24 16:17:37 : INFO  : splashtopstreamer : Latest version of Splashtop Streamer is 3.6.2.1
2024-01-24 16:17:37 : WARN  : splashtopstreamer : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-01-24 16:17:37 : REQ   : splashtopstreamer : Downloading https://download.splashtop.com/csrs/Splashtop_Streamer_Mac_DEPLOY_INSTALLER_v3.6.2.1.dmg to Splashtop Streamer.dmg
2024-01-24 16:17:37 : DEBUG : splashtopstreamer : No Dialog connection, just download
2024-01-24 16:17:39 : DEBUG : splashtopstreamer : File list: -rw-r--r--  1 root  staff    27M 24 Jan 16:17 Splashtop Streamer.dmg
2024-01-24 16:17:39 : DEBUG : splashtopstreamer : File type: Splashtop Streamer.dmg: zlib compressed data
2024-01-24 16:17:39 : DEBUG : splashtopstreamer : curl output was:
*   Trying 18.165.183.91:443...
* Connected to download.splashtop.com (18.165.183.91) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4971 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.splashtop.com
*  start date: Nov 20 00:00:00 2023 GMT
*  expire date: Dec 17 23:59:59 2024 GMT
*  subjectAltName: host "download.splashtop.com" matched cert's "*.splashtop.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.splashtop.com/csrs/Splashtop_Streamer_Mac_DEPLOY_INSTALLER_v3.6.2.1.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.splashtop.com]
* [HTTP/2] [1] [:path: /csrs/Splashtop_Streamer_Mac_DEPLOY_INSTALLER_v3.6.2.1.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /csrs/Splashtop_Streamer_Mac_DEPLOY_INSTALLER_v3.6.2.1.dmg HTTP/2
> Host: download.splashtop.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< content-type: binary/octet-stream
< content-length: 27816245
< last-modified: Mon, 11 Dec 2023 03:20:05 GMT
< x-amz-server-side-encryption: AES256
< accept-ranges: bytes
< server: AmazonS3
< date: Wed, 24 Jan 2024 15:09:49 GMT
< etag: "fc46082419ce5fc1dbd8b88b1011ca49-4"
< x-cache: Hit from cloudfront
< via: 1.1 2aefdd231d9806ea2eced3399f411f80.cloudfront.net (CloudFront) < x-amz-cf-pop: ZRH55-P1
< x-amz-cf-id: cn4OyWjC0RFrdEUhTgwSNrNDEip3nT1bgGwlSi968LGjPB4TEyi_Ug== < age: 16890
<
{ [16019 bytes data]
* Connection #0 to host download.splashtop.com left intact

2024-01-24 16:17:39 : DEBUG : splashtopstreamer : DEBUG mode 1, not checking for blocking processes
2024-01-24 16:17:39 : REQ   : splashtopstreamer : Installing Splashtop Streamer
2024-01-24 16:17:39 : INFO  : splashtopstreamer : Mounting /Users/b.kollmer/Development/Installomator/Installomator/build/Splashtop Streamer.dmg
2024-01-24 16:17:44 : DEBUG : splashtopstreamer : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $F343DE34
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $9A81A77F
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $C3D1FF09
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $45B4D5F6
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $C3D1FF09
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $DBEA5DEF
Die überprüfte CRC32-Prüfsumme ist $C9B0164D
/dev/disk5              GUID_partition_scheme
/dev/disk5s1            Apple_HFS                       /Volumes/SplashtopStreamer 1

2024-01-24 16:17:44 : INFO  : splashtopstreamer : Mounted: /Volumes/SplashtopStreamer 1 2024-01-24 16:17:44 : DEBUG : splashtopstreamer : Found pkg(s): /Volumes/SplashtopStreamer 1/.Splashtop Streamer.pkg 2024-01-24 16:17:44 : INFO  : splashtopstreamer : found pkg: /Volumes/SplashtopStreamer 1/.Splashtop Streamer.pkg 2024-01-24 16:17:44 : INFO  : splashtopstreamer : Verifying: /Volumes/SplashtopStreamer 1/.Splashtop Streamer.pkg
2024-01-24 16:17:44 : DEBUG : splashtopstreamer : File list: -rw-r--r--  1 root  wheel    25M  6 Dez 05:08 /Volumes/SplashtopStreamer 1/.Splashtop Streamer.pkg
2024-01-24 16:17:44 : DEBUG : splashtopstreamer : File type: /Volumes/SplashtopStreamer 1/.Splashtop Streamer.pkg: xar archive compressed TOC: 4566, SHA-1 checksum
2024-01-24 16:17:44 : DEBUG : splashtopstreamer : spctlOut is /Volumes/SplashtopStreamer 1/.Splashtop Streamer.pkg: accepted
2024-01-24 16:17:44 : DEBUG : splashtopstreamer : source=Notarized Developer ID
2024-01-24 16:17:44 : DEBUG : splashtopstreamer : origin=Developer ID Installer: Splashtop Inc. (CPQQ3AW49Y)
2024-01-24 16:17:44 : INFO  : splashtopstreamer : Team ID: CPQQ3AW49Y (expected: CPQQ3AW49Y )
2024-01-24 16:17:44 : DEBUG : splashtopstreamer : DEBUG enabled, skipping installation
2024-01-24 16:17:44 : INFO  : splashtopstreamer : Finishing...
2024-01-24 16:17:47 : INFO  : splashtopstreamer : App(s) found: /Applications/Splashtop Streamer.app
2024-01-24 16:17:47 : INFO  : splashtopstreamer : found app at /Applications/Splashtop Streamer.app, version 3.6.2.1, on versionKey CFBundleShortVersionString
2024-01-24 16:17:47 : REQ   : splashtopstreamer : Installed Splashtop Streamer, version 3.6.2.1
2024-01-24 16:17:47 : INFO  : splashtopstreamer : notifying
2024-01-24 16:17:47 : DEBUG : splashtopstreamer : Unmounting /Volumes/SplashtopStreamer 1
2024-01-24 16:17:47 : DEBUG : splashtopstreamer : Debugging enabled, Unmounting output was:
"disk5" ejected.
2024-01-24 16:17:47 : DEBUG : splashtopstreamer : DEBUG mode 1, not reopening anything
2024-01-24 16:17:47 : REQ   : splashtopstreamer : All done!
2024-01-24 16:17:47 : REQ   : splashtopstreamer : ################## End Installomator, exit code 0