### PR TITLE
Create lunadisplay.sh

### DIFF
--- a/fragments/labels/lunadisplay.sh
+++ b/fragments/labels/lunadisplay.sh
@@ -1,0 +1,7 @@
+lunadisplay)
+    name="Luna Display"
+    type="dmg"
+    downloadURL=$(curl -fsLI "https://downloads.astropad.com/luna/mac/latest" | grep -i '^location:' | tail -n 1 | cut -d ' ' -f 2 | tr -d '\r' | sed 's|^/|https://downloads.astropad.com/|')
+    appNewVersion=$(echo $downloadURL | sed -E 's/.*LunaDisplay-([0-9.]+).dmg/\1/')
+    expectedTeamID="8356ZZ8Y5K"
+    ;;


### PR DESCRIPTION
# fragments/labels not a directory, skipping...
2024-01-29 15:11:37 : REQ   : lunadisplay : ################## Start Installomator v. 10.6beta, date 2024-01-29
2024-01-29 15:11:37 : INFO  : lunadisplay : ################## Version: 10.6beta
2024-01-29 15:11:37 : INFO  : lunadisplay : ################## Date: 2024-01-29
2024-01-29 15:11:37 : INFO  : lunadisplay : ################## lunadisplay
2024-01-29 15:11:37 : DEBUG : lunadisplay : DEBUG mode 1 enabled.
2024-01-29 15:11:38 : DEBUG : lunadisplay : name=Luna Display
2024-01-29 15:11:38 : DEBUG : lunadisplay : appName=
2024-01-29 15:11:38 : DEBUG : lunadisplay : type=dmg
2024-01-29 15:11:38 : DEBUG : lunadisplay : archiveName=
2024-01-29 15:11:38 : DEBUG : lunadisplay : downloadURL=https://downloads.astropad.com/luna/mac/LunaDisplay-5.3.3.4813.dmg
2024-01-29 15:11:38 : DEBUG : lunadisplay : curlOptions=
2024-01-29 15:11:38 : DEBUG : lunadisplay : appNewVersion=5.3.3.4813
2024-01-29 15:11:38 : DEBUG : lunadisplay : appCustomVersion function: Not defined
2024-01-29 15:11:38 : DEBUG : lunadisplay : versionKey=CFBundleShortVersionString
2024-01-29 15:11:38 : DEBUG : lunadisplay : packageID=
2024-01-29 15:11:38 : DEBUG : lunadisplay : pkgName=
2024-01-29 15:11:38 : DEBUG : lunadisplay : choiceChangesXML=
2024-01-29 15:11:38 : DEBUG : lunadisplay : expectedTeamID=8356ZZ8Y5K
2024-01-29 15:11:38 : DEBUG : lunadisplay : blockingProcesses=
2024-01-29 15:11:38 : DEBUG : lunadisplay : installerTool=
2024-01-29 15:11:38 : DEBUG : lunadisplay : CLIInstaller=
2024-01-29 15:11:38 : DEBUG : lunadisplay : CLIArguments=
2024-01-29 15:11:38 : DEBUG : lunadisplay : updateTool=
2024-01-29 15:11:38 : DEBUG : lunadisplay : updateToolArguments=
2024-01-29 15:11:38 : DEBUG : lunadisplay : updateToolRunAsCurrentUser=
2024-01-29 15:11:38 : INFO  : lunadisplay : BLOCKING_PROCESS_ACTION=tell_user
2024-01-29 15:11:38 : INFO  : lunadisplay : NOTIFY=success
2024-01-29 15:11:38 : INFO  : lunadisplay : LOGGING=DEBUG
2024-01-29 15:11:38 : INFO  : lunadisplay : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-29 15:11:38 : INFO  : lunadisplay : Label type: dmg
2024-01-29 15:11:38 : INFO  : lunadisplay : archiveName: Luna Display.dmg
2024-01-29 15:11:38 : INFO  : lunadisplay : no blocking processes defined, using Luna Display as default
2024-01-29 15:11:38 : DEBUG : lunadisplay : Changing directory to /Users/b.kollmer/Development/Installomator/Installomator/build
2024-01-29 15:11:38 : INFO  : lunadisplay : name: Luna Display, appName: Luna Display.app
2024-01-29 15:11:38.255 mdfind[77542:38223976] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2024-01-29 15:11:38.256 mdfind[77542:38223976] [UserQueryParser] Loading keywords and predicates for locale "de"
2024-01-29 15:11:38.428 mdfind[77542:38223976] Couldn't determine the mapping between prefab keywords and predicates.
2024-01-29 15:11:38 : WARN  : lunadisplay : No previous app found
2024-01-29 15:11:38 : WARN  : lunadisplay : could not find Luna Display.app
2024-01-29 15:11:38 : INFO  : lunadisplay : appversion:
2024-01-29 15:11:38 : INFO  : lunadisplay : Latest version of Luna Display is 5.3.3.4813
2024-01-29 15:11:38 : REQ   : lunadisplay : Downloading https://downloads.astropad.com/luna/mac/LunaDisplay-5.3.3.4813.dmg to Luna Display.dmg
2024-01-29 15:11:38 : DEBUG : lunadisplay : No Dialog connection, just download
2024-01-29 15:11:40 : DEBUG : lunadisplay : File list: -rw-r--r--  1 root  staff    46M 29 Jan 15:11 Luna Display.dmg
2024-01-29 15:11:40 : DEBUG : lunadisplay : File type: Luna Display.dmg: lzfse encoded, lzvn compressed
2024-01-29 15:11:40 : DEBUG : lunadisplay : curl output was:
*   Trying 18.66.248.21:443...
* Connected to downloads.astropad.com (18.66.248.21) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4970 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=downloads.astropad.com
*  start date: Jul 17 00:00:00 2023 GMT
*  expire date: Aug 14 23:59:59 2024 GMT
*  subjectAltName: host "downloads.astropad.com" matched cert's "downloads.astropad.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://downloads.astropad.com/luna/mac/LunaDisplay-5.3.3.4813.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: downloads.astropad.com]
* [HTTP/2] [1] [:path: /luna/mac/LunaDisplay-5.3.3.4813.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /luna/mac/LunaDisplay-5.3.3.4813.dmg HTTP/2
> Host: downloads.astropad.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/x-apple-diskimage
< content-length: 48449584
< date: Mon, 29 Jan 2024 14:11:39 GMT
< last-modified: Mon, 04 Dec 2023 19:12:16 GMT
< x-amz-version-id: 6gJ5Fq_jOBjoWa0ZKm_d2bMcwi2GndjL < etag: "e128acfd338a141e506e73f3fb0c116c-6"
< server: AmazonS3
< x-cache: Miss from cloudfront
< via: 1.1 6fadd80db8a3a154b0b68f055a91920c.cloudfront.net (CloudFront) < x-amz-cf-pop: DUS51-P1
< x-amz-cf-id: d3w2ItTe5x4_G7756bS8i8a50EL40hKkPW2EvJF7M7SbQDiKKcK51w== <
{ [3573 bytes data]
* Connection #0 to host downloads.astropad.com left intact

2024-01-29 15:11:40 : DEBUG : lunadisplay : DEBUG mode 1, not checking for blocking processes
2024-01-29 15:11:40 : REQ   : lunadisplay : Installing Luna Display
2024-01-29 15:11:40 : INFO  : lunadisplay : Mounting /Users/b.kollmer/Development/Installomator/Installomator/build/Luna Display.dmg
2024-01-29 15:11:45 : DEBUG : lunadisplay : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $F71F9AE4
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $408503BA
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $B090DABE
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $90960A47
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $B090DABE
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $58C8336C
Die überprüfte CRC32-Prüfsumme ist $80FB3EA4
/dev/disk8              GUID_partition_scheme
/dev/disk8s1            Apple_HFS                       /Volumes/Luna Display 1

2024-01-29 15:11:45 : INFO  : lunadisplay : Mounted: /Volumes/Luna Display 1 2024-01-29 15:11:45 : INFO  : lunadisplay : Verifying: /Volumes/Luna Display 1/Luna Display.app
2024-01-29 15:11:45 : DEBUG : lunadisplay : App size: 118M      /Volumes/Luna Display 1/Luna Display.app
2024-01-29 15:11:46 : DEBUG : lunadisplay : Debugging enabled, App Verification output was:
/Volumes/Luna Display 1/Luna Display.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Astro HQ LLC (8356ZZ8Y5K)

2024-01-29 15:11:46 : INFO  : lunadisplay : Team ID matching: 8356ZZ8Y5K (expected: 8356ZZ8Y5K ) 2024-01-29 15:11:46 : INFO  : lunadisplay : Installing Luna Display version 5.3.3 on versionKey CFBundleShortVersionString. 2024-01-29 15:11:46 : INFO  : lunadisplay : App has LSMinimumSystemVersion: 10.11 2024-01-29 15:11:46 : DEBUG : lunadisplay : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2024-01-29 15:11:46 : INFO  : lunadisplay : Finishing... 2024-01-29 15:11:49 : INFO  : lunadisplay : name: Luna Display, appName: Luna Display.app 2024-01-29 15:11:49.895 mdfind[77682:38224723] [UserQueryParser] Loading keywords and predicates for locale "de_DE" 2024-01-29 15:11:49.896 mdfind[77682:38224723] [UserQueryParser] Loading keywords and predicates for locale "de" 2024-01-29 15:11:49.961 mdfind[77682:38224723] Couldn't determine the mapping between prefab keywords and predicates. 2024-01-29 15:11:50 : WARN  : lunadisplay : No previous app found 2024-01-29 15:11:50 : WARN  : lunadisplay : could not find Luna Display.app
2024-01-29 15:11:50 : REQ   : lunadisplay : Installed Luna Display, version 5.3.3
2024-01-29 15:11:50 : INFO  : lunadisplay : notifying
2024-01-29 15:11:50 : DEBUG : lunadisplay : Unmounting /Volumes/Luna Display 1
2024-01-29 15:11:50 : DEBUG : lunadisplay : Debugging enabled, Unmounting output was:
"disk8" ejected.
2024-01-29 15:11:50 : DEBUG : lunadisplay : DEBUG mode 1, not reopening anything
2024-01-29 15:11:50 : REQ   : lunadisplay : All done!
2024-01-29 15:11:50 : REQ   : lunadisplay : ################## End Installomator, exit code 0