### PR TITLE
Create starface81x.sh

### DIFF
--- a/fragments/labels/starface81x.sh
+++ b/fragments/labels/starface81x.sh
@@ -1,0 +1,9 @@
+starface81x)
+    name="STARFACE"
+    # Downloads the latest 8.1.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation
+    type="dmg"
+    downloadURL=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "8.1" | cut -d '"' -f 10)
+    appNewVersion=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "8.1" | cut -d '"' -f 4)
+    expectedTeamID="Q965D3UXEW"
+    versionKey="CFBundleVersion"
+    ;;


### PR DESCRIPTION
2024-06-20 10:17:20 : REQ   : starface81x : ################## Start Installomator v. 10.6.9, date 2024-06-20
2024-06-20 10:17:20 : INFO  : starface81x : ################## Version: 10.6.9
2024-06-20 10:17:20 : INFO  : starface81x : ################## Date: 2024-06-20
2024-06-20 10:17:20 : INFO  : starface81x : ################## starface81x
2024-06-20 10:17:20 : DEBUG : starface81x : DEBUG mode 1 enabled.
2024-06-20 10:17:21 : DEBUG : starface81x : name=STARFACE
2024-06-20 10:17:21 : DEBUG : starface81x : appName=
2024-06-20 10:17:21 : DEBUG : starface81x : type=dmg
2024-06-20 10:17:21 : DEBUG : starface81x : archiveName=
2024-06-20 10:17:21 : DEBUG : starface81x : downloadURL=https://www.starface-cdn.de/starface/clients/mac/STARFACE_8.1.2_977_639a503.dmg
2024-06-20 10:17:21 : DEBUG : starface81x : curlOptions=
2024-06-20 10:17:21 : DEBUG : starface81x : appNewVersion=8.1.2
2024-06-20 10:17:21 : DEBUG : starface81x : appCustomVersion function: Not defined
2024-06-20 10:17:21 : DEBUG : starface81x : versionKey=CFBundleVersion
2024-06-20 10:17:21 : DEBUG : starface81x : packageID=
2024-06-20 10:17:21 : DEBUG : starface81x : pkgName=
2024-06-20 10:17:21 : DEBUG : starface81x : choiceChangesXML=
2024-06-20 10:17:21 : DEBUG : starface81x : expectedTeamID=Q965D3UXEW
2024-06-20 10:17:21 : DEBUG : starface81x : blockingProcesses=
2024-06-20 10:17:21 : DEBUG : starface81x : installerTool=
2024-06-20 10:17:21 : DEBUG : starface81x : CLIInstaller=
2024-06-20 10:17:21 : DEBUG : starface81x : CLIArguments=
2024-06-20 10:17:21 : DEBUG : starface81x : updateTool=
2024-06-20 10:17:21 : DEBUG : starface81x : updateToolArguments=
2024-06-20 10:17:21 : DEBUG : starface81x : updateToolRunAsCurrentUser=
2024-06-20 10:17:21 : INFO  : starface81x : BLOCKING_PROCESS_ACTION=tell_user
2024-06-20 10:17:21 : INFO  : starface81x : NOTIFY=silent
2024-06-20 10:17:21 : INFO  : starface81x : LOGGING=DEBUG
2024-06-20 10:17:21 : INFO  : starface81x : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-06-20 10:17:21 : INFO  : starface81x : Label type: dmg
2024-06-20 10:17:21 : INFO  : starface81x : archiveName: STARFACE.dmg
2024-06-20 10:17:21 : INFO  : starface81x : no blocking processes defined, using STARFACE as default
2024-06-20 10:17:21 : DEBUG : starface81x : Changing directory to .
2024-06-20 10:17:21 : INFO  : starface81x : App(s) found: /Applications/STARFACE.app
2024-06-20 10:17:21 : INFO  : starface81x : found app at /Applications/STARFACE.app, version 977, on versionKey CFBundleVersion
2024-06-20 10:17:21 : INFO  : starface81x : appversion: 977
2024-06-20 10:17:21 : INFO  : starface81x : Latest version of STARFACE is 8.1.2
2024-06-20 10:17:21 : REQ   : starface81x : Downloading https://www.starface-cdn.de/starface/clients/mac/STARFACE_8.1.2_977_639a503.dmg to STARFACE.dmg
2024-06-20 10:17:21 : DEBUG : starface81x : No Dialog connection, just download
2024-06-20 10:17:23 : DEBUG : starface81x : File list: -rw-r--r--  1 root  staff   196M 20 Jun 10:17 STARFACE.dmg
2024-06-20 10:17:23 : DEBUG : starface81x : File type: STARFACE.dmg: zlib compressed data
2024-06-20 10:17:23 : DEBUG : starface81x : curl output was:
* Host www.starface-cdn.de:443 was resolved.
* IPv6: (none)
* IPv4: 217.160.0.241
*   Trying 217.160.0.241:443...
* Connected to www.starface-cdn.de (217.160.0.241) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [70 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2762 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.starface-cdn.de
*  start date: Oct  2 00:00:00 2023 GMT
*  expire date: Oct 16 23:59:59 2024 GMT
*  subjectAltName: host "www.starface-cdn.de" matched cert's "*.starface-cdn.de"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=Encryption Everywhere DV TLS CA - G2
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.starface-cdn.de/starface/clients/mac/STARFACE_8.1.2_977_639a503.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.starface-cdn.de]
* [HTTP/2] [1] [:path: /starface/clients/mac/STARFACE_8.1.2_977_639a503.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /starface/clients/mac/STARFACE_8.1.2_977_639a503.dmg HTTP/2
> Host: www.starface-cdn.de
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/2 200 
< content-type: application/x-apple-diskimage
< content-length: 205209428
< date: Thu, 20 Jun 2024 08:17:21 GMT
< server: Apache
< last-modified: Tue, 28 May 2024 12:03:42 GMT
< etag: "c3b3f54-619826ccbc380"
< accept-ranges: bytes
< 
{ [16207 bytes data]
* Connection #0 to host www.starface-cdn.de left intact

2024-06-20 10:17:23 : DEBUG : starface81x : DEBUG mode 1, not checking for blocking processes
2024-06-20 10:17:23 : REQ   : starface81x : Installing STARFACE
2024-06-20 10:17:23 : INFO  : starface81x : Mounting ./STARFACE.dmg
2024-06-20 10:17:25 : DEBUG : starface81x : Debugging enabled, dmgmount output was:
Prüfsumme für Driver Descriptor Map (DDM : 0) berechnen …
Driver Descriptor Map (DDM : 0): Die überprüfte CRC32-Prüfsumme ist $D8F19DA5
Prüfsumme für Apple (Apple_partition_map : 1) berechnen …
Apple (Apple_partition_map : 1): Die überprüfte CRC32-Prüfsumme ist $FFFFA31B
Prüfsumme für DiscRecording 9.0.3d5 (Apple_HFS : 2) berechnen …
DiscRecording 9.0.3d5 (Apple_HFS : 2: Die überprüfte CRC32-Prüfsumme ist $B3FD8844
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Die überprüfte CRC32-Prüfsumme ist $E4B41381
/dev/disk7              Apple_partition_scheme
/dev/disk7s1            Apple_partition_map
/dev/disk7s2            Apple_HFS                       /Volumes/STARFACE Installer

2024-06-20 10:17:25 : INFO  : starface81x : Mounted: /Volumes/STARFACE Installer
2024-06-20 10:17:25 : INFO  : starface81x : Verifying: /Volumes/STARFACE Installer/STARFACE.app
2024-06-20 10:17:25 : DEBUG : starface81x : App size: 471M      /Volumes/STARFACE Installer/STARFACE.app
2024-06-20 10:17:26 : DEBUG : starface81x : Debugging enabled, App Verification output was:
/Volumes/STARFACE Installer/STARFACE.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: STARFACE GmbH (Q965D3UXEW)

2024-06-20 10:17:26 : INFO  : starface81x : Team ID matching: Q965D3UXEW (expected: Q965D3UXEW )
2024-06-20 10:17:26 : INFO  : starface81x : Downloaded version of STARFACE is 977 on versionKey CFBundleVersion, same as installed.
2024-06-20 10:17:26 : DEBUG : starface81x : Unmounting /Volumes/STARFACE Installer
2024-06-20 10:17:26 : DEBUG : starface81x : Debugging enabled, Unmounting output was:
"disk7" ejected.
2024-06-20 10:17:26 : DEBUG : starface81x : DEBUG mode 1, not reopening anything
2024-06-20 10:17:26 : REG   : starface81x : No new version to install
2024-06-20 10:17:26 : REQ   : starface81x : ################## End Installomator, exit code 0 