### PR TITLE
Update bambustudio.sh

### DIFF
--- a/fragments/labels/bambustudio.sh
+++ b/fragments/labels/bambustudio.sh
@@ -3,5 +3,5 @@ bambustudio)
     type="dmg"
     downloadURL=$(downloadURLFromGit "bambulab" "BambuStudio")
     appNewVersion=$(versionFromGit "bambulab" "BambuStudio")
-    expectedTeamID="F4SKHPXDD9"
+    expectedTeamID="T3UBR9Y3B2"
     ;;


### PR DESCRIPTION
2024-06-20 14:24:56 : REQ   : bambustudio : ################## Start Installomator v. 10.6beta, date 2024-06-20
2024-06-20 14:24:56 : INFO  : bambustudio : ################## Version: 10.6beta
2024-06-20 14:24:56 : INFO  : bambustudio : ################## Date: 2024-06-20
2024-06-20 14:24:56 : INFO  : bambustudio : ################## bambustudio
2024-06-20 14:24:56 : DEBUG : bambustudio : DEBUG mode 1 enabled.
2024-06-20 14:24:57 : DEBUG : bambustudio : name=BambuStudio
2024-06-20 14:24:57 : DEBUG : bambustudio : appName=
2024-06-20 14:24:57 : DEBUG : bambustudio : type=dmg
2024-06-20 14:24:57 : DEBUG : bambustudio : archiveName=
2024-06-20 14:24:57 : DEBUG : bambustudio : downloadURL=https://github.com/bambulab/BambuStudio/releases/download/v01.09.02.57/Bambu_Studio_mac-v01.09.02.57-20240607194639.dmg
2024-06-20 14:24:57 : DEBUG : bambustudio : curlOptions=
2024-06-20 14:24:57 : DEBUG : bambustudio : appNewVersion=01.09.02.57
2024-06-20 14:24:57 : DEBUG : bambustudio : appCustomVersion function: Not defined
2024-06-20 14:24:57 : DEBUG : bambustudio : versionKey=CFBundleShortVersionString
2024-06-20 14:24:57 : DEBUG : bambustudio : packageID=
2024-06-20 14:24:57 : DEBUG : bambustudio : pkgName=
2024-06-20 14:24:57 : DEBUG : bambustudio : choiceChangesXML=
2024-06-20 14:24:57 : DEBUG : bambustudio : expectedTeamID=T3UBR9Y3B2
2024-06-20 14:24:57 : DEBUG : bambustudio : blockingProcesses=
2024-06-20 14:24:57 : DEBUG : bambustudio : installerTool=
2024-06-20 14:24:57 : DEBUG : bambustudio : CLIInstaller=
2024-06-20 14:24:57 : DEBUG : bambustudio : CLIArguments=
2024-06-20 14:24:57 : DEBUG : bambustudio : updateTool=
2024-06-20 14:24:57 : DEBUG : bambustudio : updateToolArguments=
2024-06-20 14:24:57 : DEBUG : bambustudio : updateToolRunAsCurrentUser=
2024-06-20 14:24:57 : INFO  : bambustudio : BLOCKING_PROCESS_ACTION=tell_user
2024-06-20 14:24:57 : INFO  : bambustudio : NOTIFY=success
2024-06-20 14:24:57 : INFO  : bambustudio : LOGGING=DEBUG
2024-06-20 14:24:57 : INFO  : bambustudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-06-20 14:24:57 : INFO  : bambustudio : Label type: dmg
2024-06-20 14:24:57 : INFO  : bambustudio : archiveName: BambuStudio.dmg
2024-06-20 14:24:57 : INFO  : bambustudio : no blocking processes defined, using BambuStudio as default
2024-06-20 14:24:57 : DEBUG : bambustudio : Changing directory to .
2024-06-20 14:24:57 : INFO  : bambustudio : App(s) found: /Applications/BambuStudio.app
2024-06-20 14:24:57 : INFO  : bambustudio : found app at /Applications/BambuStudio.app, version 01.09.02.57, on versionKey CFBundleShortVersionString
2024-06-20 14:24:57 : INFO  : bambustudio : appversion: 01.09.02.57
2024-06-20 14:24:57 : INFO  : bambustudio : Latest version of BambuStudio is 01.09.02.57
2024-06-20 14:24:57 : WARN  : bambustudio : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-06-20 14:24:57 : REQ   : bambustudio : Downloading https://github.com/bambulab/BambuStudio/releases/download/v01.09.02.57/Bambu_Studio_mac-v01.09.02.57-20240607194639.dmg to BambuStudio.dmg
2024-06-20 14:24:57 : DEBUG : bambustudio : No Dialog connection, just download
2024-06-20 14:25:00 : DEBUG : bambustudio : File list: -rw-r--r--  1 root  staff   130M 20 Jun 14:25 BambuStudio.dmg
2024-06-20 14:25:00 : DEBUG : bambustudio : File type: BambuStudio.dmg: zlib compressed data
2024-06-20 14:25:00 : DEBUG : bambustudio : curl output was:
* Host github.com:443 was resolved.
* IPv6: (none)
* IPv4: 140.82.121.3
*   Trying 140.82.121.3:443...
* Connected to github.com (140.82.121.3) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3137 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=github.com
*  start date: Mar  7 00:00:00 2024 GMT
*  expire date: Mar  7 23:59:59 2025 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo ECC Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/bambulab/BambuStudio/releases/download/v01.09.02.57/Bambu_Studio_mac-v01.09.02.57-20240607194639.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /bambulab/BambuStudio/releases/download/v01.09.02.57/Bambu_Studio_mac-v01.09.02.57-20240607194639.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /bambulab/BambuStudio/releases/download/v01.09.02.57/Bambu_Studio_mac-v01.09.02.57-20240607194639.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/2 302 
< server: GitHub.com
< date: Thu, 20 Jun 2024 12:24:57 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/511797274/b7de6619-0e73-42d3-b611-3b6a1947eaaa?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240620%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240620T122457Z&X-Amz-Expires=300&X-Amz-Signature=9bcb6778835856f3aaf3dbd81771ade599a416783a88546137ffc7ba34ef140d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=511797274&response-content-disposition=attachment%3B%20filename%3DBambu_Studio_mac-v01.09.02.57-20240607194639.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com api.githubcopilot.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com/v1/engines/github-completion/completions *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: E622:10977D:D06C5BA:D44039C:66741F99
< 
* Ignoring the response-body
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/511797274/b7de6619-0e73-42d3-b611-3b6a1947eaaa?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240620%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240620T122457Z&X-Amz-Expires=300&X-Amz-Signature=9bcb6778835856f3aaf3dbd81771ade599a416783a88546137ffc7ba34ef140d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=511797274&response-content-disposition=attachment%3B%20filename%3DBambu_Studio_mac-v01.09.02.57-20240607194639.dmg&response-content-type=application%2Foctet-stream'
* Host objects.githubusercontent.com:443 was resolved.
* IPv6: (none)
* IPv4: 185.199.108.133, 185.199.110.133, 185.199.109.133, 185.199.111.133
*   Trying 185.199.108.133:443...
* Connected to objects.githubusercontent.com (185.199.108.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3099 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 15 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/511797274/b7de6619-0e73-42d3-b611-3b6a1947eaaa?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240620%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240620T122457Z&X-Amz-Expires=300&X-Amz-Signature=9bcb6778835856f3aaf3dbd81771ade599a416783a88546137ffc7ba34ef140d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=511797274&response-content-disposition=attachment%3B%20filename%3DBambu_Studio_mac-v01.09.02.57-20240607194639.dmg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/511797274/b7de6619-0e73-42d3-b611-3b6a1947eaaa?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240620%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240620T122457Z&X-Amz-Expires=300&X-Amz-Signature=9bcb6778835856f3aaf3dbd81771ade599a416783a88546137ffc7ba34ef140d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=511797274&response-content-disposition=attachment%3B%20filename%3DBambu_Studio_mac-v01.09.02.57-20240607194639.dmg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/511797274/b7de6619-0e73-42d3-b611-3b6a1947eaaa?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240620%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240620T122457Z&X-Amz-Expires=300&X-Amz-Signature=9bcb6778835856f3aaf3dbd81771ade599a416783a88546137ffc7ba34ef140d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=511797274&response-content-disposition=attachment%3B%20filename%3DBambu_Studio_mac-v01.09.02.57-20240607194639.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< last-modified: Tue, 11 Jun 2024 11:25:14 GMT
< etag: "0x8DC8A0929D8580B"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 0b6240e9-f01e-002e-52f8-bbb342000000
< x-ms-version: 2020-10-02
< x-ms-creation-time: Tue, 11 Jun 2024 11:25:14 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Bambu_Studio_mac-v01.09.02.57-20240607194639.dmg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< age: 1243
< date: Thu, 20 Jun 2024 12:24:58 GMT
< x-served-by: cache-iad-kcgs7200154-IAD, cache-fra-eddf8230045-FRA
< x-cache: HIT, HIT
< x-cache-hits: 6091, 0
< x-timer: S1718886298.097907,VS0,VE372
< content-length: 135936232
< 
{ [4986 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-06-20 14:25:00 : DEBUG : bambustudio : DEBUG mode 1, not checking for blocking processes
2024-06-20 14:25:00 : REQ   : bambustudio : Installing BambuStudio
2024-06-20 14:25:00 : INFO  : bambustudio : Mounting ./BambuStudio.dmg
2024-06-20 14:25:04 : DEBUG : bambustudio : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $595FCAE3
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $CC1B657E
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $18E27956
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $75809172
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $18E27956
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $0E462C43
Die überprüfte CRC32-Prüfsumme ist $B6D2765E
/dev/disk9              GUID_partition_scheme
/dev/disk9s1            Apple_HFS                       /Volumes/Bambu Studio 1

2024-06-20 14:25:04 : INFO  : bambustudio : Mounted: /Volumes/Bambu Studio 1
2024-06-20 14:25:04 : INFO  : bambustudio : Verifying: /Volumes/Bambu Studio 1/BambuStudio.app
2024-06-20 14:25:04 : DEBUG : bambustudio : App size: 312M      /Volumes/Bambu Studio 1/BambuStudio.app
2024-06-20 14:25:07 : DEBUG : bambustudio : Debugging enabled, App Verification output was:
/Volumes/Bambu Studio 1/BambuStudio.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Shanghai Lunkuo Technology Co., Ltd (T3UBR9Y3B2)

2024-06-20 14:25:07 : INFO  : bambustudio : Team ID matching: T3UBR9Y3B2 (expected: T3UBR9Y3B2 )
2024-06-20 14:25:07 : INFO  : bambustudio : Downloaded version of BambuStudio is 01.09.02.57 on versionKey CFBundleShortVersionString, same as installed.
2024-06-20 14:25:07 : DEBUG : bambustudio : Unmounting /Volumes/Bambu Studio 1
2024-06-20 14:25:18 : DEBUG : bambustudio : Debugging enabled, Unmounting output was:
"disk9" ejected.
2024-06-20 14:25:18 : DEBUG : bambustudio : DEBUG mode 1, not reopening anything
2024-06-20 14:25:18 : REG   : bambustudio : No new version to install
2024-06-20 14:25:18 : REQ   : bambustudio : ################## End Installomator, exit code 0