### PR TITLE
Create macgiro13.sh

### DIFF
--- a/fragments/labels/macgiro13.sh
+++ b/fragments/labels/macgiro13.sh
@@ -1,0 +1,7 @@
+macgiro13)
+    name="MacGiro 13"
+    type="pkg"
+    downloadURL="https://www.med-i-bit.de/130YW3nnEPlqSnRB7ROM/MacGiro130.pkg"
+    expectedTeamID="G458QMSYRT"
+    versionKey="CFBundleShortVersionString"
+    ;;


### PR DESCRIPTION
2024-07-09 09:28:14 : REQ   : macgiro13 : ################## Start Installomator v. 10.6beta, date 2024-07-09
2024-07-09 09:28:14 : INFO  : macgiro13 : ################## Version: 10.6beta
2024-07-09 09:28:14 : INFO  : macgiro13 : ################## Date: 2024-07-09
2024-07-09 09:28:14 : INFO  : macgiro13 : ################## macgiro13
2024-07-09 09:28:14 : DEBUG : macgiro13 : DEBUG mode 1 enabled.
2024-07-09 09:28:14 : DEBUG : macgiro13 : name=MacGiro 13
2024-07-09 09:28:14 : DEBUG : macgiro13 : appName=
2024-07-09 09:28:14 : DEBUG : macgiro13 : type=pkg
2024-07-09 09:28:14 : DEBUG : macgiro13 : archiveName=
2024-07-09 09:28:14 : DEBUG : macgiro13 : downloadURL=https://www.med-i-bit.de/130YW3nnEPlqSnRB7ROM/MacGiro130.pkg
2024-07-09 09:28:14 : DEBUG : macgiro13 : curlOptions=
2024-07-09 09:28:14 : DEBUG : macgiro13 : appNewVersion=
2024-07-09 09:28:14 : DEBUG : macgiro13 : appCustomVersion function: Not defined
2024-07-09 09:28:14 : DEBUG : macgiro13 : versionKey=CFBundleShortVersionString
2024-07-09 09:28:14 : DEBUG : macgiro13 : packageID=
2024-07-09 09:28:14 : DEBUG : macgiro13 : pkgName=
2024-07-09 09:28:14 : DEBUG : macgiro13 : choiceChangesXML=
2024-07-09 09:28:14 : DEBUG : macgiro13 : expectedTeamID=G458QMSYRT
2024-07-09 09:28:14 : DEBUG : macgiro13 : blockingProcesses=
2024-07-09 09:28:14 : DEBUG : macgiro13 : installerTool=
2024-07-09 09:28:14 : DEBUG : macgiro13 : CLIInstaller=
2024-07-09 09:28:14 : DEBUG : macgiro13 : CLIArguments=
2024-07-09 09:28:14 : DEBUG : macgiro13 : updateTool=
2024-07-09 09:28:14 : DEBUG : macgiro13 : updateToolArguments=
2024-07-09 09:28:14 : DEBUG : macgiro13 : updateToolRunAsCurrentUser=
2024-07-09 09:28:14 : INFO  : macgiro13 : BLOCKING_PROCESS_ACTION=tell_user
2024-07-09 09:28:14 : INFO  : macgiro13 : NOTIFY=success
2024-07-09 09:28:14 : INFO  : macgiro13 : LOGGING=DEBUG
2024-07-09 09:28:14 : INFO  : macgiro13 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-09 09:28:14 : INFO  : macgiro13 : Label type: pkg
2024-07-09 09:28:14 : INFO  : macgiro13 : archiveName: MacGiro 13.pkg
2024-07-09 09:28:14 : INFO  : macgiro13 : no blocking processes defined, using MacGiro 13 as default
2024-07-09 09:28:14 : DEBUG : macgiro13 : Changing directory to .
2024-07-09 09:28:14 : INFO  : macgiro13 : name: MacGiro 13, appName: MacGiro 13.app
2024-07-09 09:28:14.492 mdfind[12289:2309537] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2024-07-09 09:28:14.492 mdfind[12289:2309537] [UserQueryParser] Loading keywords and predicates for locale "de"
2024-07-09 09:28:14.731 mdfind[12289:2309537] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-09 09:28:14 : WARN  : macgiro13 : No previous app found
2024-07-09 09:28:14 : WARN  : macgiro13 : could not find MacGiro 13.app
2024-07-09 09:28:14 : INFO  : macgiro13 : appversion:
2024-07-09 09:28:14 : INFO  : macgiro13 : Latest version not specified.
2024-07-09 09:28:14 : REQ   : macgiro13 : Downloading https://www.med-i-bit.de/130YW3nnEPlqSnRB7ROM/MacGiro130.pkg to MacGiro 13.pkg
2024-07-09 09:28:14 : DEBUG : macgiro13 : No Dialog connection, just download
2024-07-09 09:28:21 : DEBUG : macgiro13 : File list: -rw-r--r--  1 root  staff    55M  9 Jul 09:28 MacGiro 13.pkg
2024-07-09 09:28:21 : DEBUG : macgiro13 : File type: MacGiro 13.pkg: xar archive compressed TOC: 4689, SHA-1 checksum
2024-07-09 09:28:21 : DEBUG : macgiro13 : curl output was:
* Host www.med-i-bit.de:443 was resolved.
* IPv6: (none)
* IPv4: 212.223.167.107
*   Trying 212.223.167.107:443...
* Connected to www.med-i-bit.de (212.223.167.107) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [93 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [5118 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [589 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: serialNumber=HRB 39727; jurisdictionCountryName=DE; businessCategory=Private Organization; C=DE; ST=Hamburg; O=med-i-bit EDV-Beratungsgesellschaft mbH; CN=www.med-i-bit.de
*  start date: Nov  6 00:00:00 2023 GMT
*  expire date: Nov  6 23:59:59 2024 GMT
*  subjectAltName: host "www.med-i-bit.de" matched cert's "www.med-i-bit.de"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Extended Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /130YW3nnEPlqSnRB7ROM/MacGiro130.pkg HTTP/1.1
> Host: www.med-i-bit.de
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Tue, 09 Jul 2024 07:28:00 GMT
< Server: Apache
< Last-Modified: Fri, 03 Mar 2023 08:08:54 GMT
< ETag: "b00c1b-36dc10e-5f5fa74d833f9"
< Accept-Ranges: bytes
< Content-Length: 57524494
< X-Powered-By: PleskLin
< Connection: close
< Content-Type: application/vnd.apple.installer+xml <
{ [16384 bytes data]
* Closing connection
* TLSv1.2 (IN), TLS alert, close notify (256): { [2 bytes data]
* TLSv1.2 (OUT), TLS alert, close notify (256): } [2 bytes data]

2024-07-09 09:28:21 : DEBUG : macgiro13 : DEBUG mode 1, not checking for blocking processes
2024-07-09 09:28:21 : REQ   : macgiro13 : Installing MacGiro 13
2024-07-09 09:28:21 : INFO  : macgiro13 : Verifying: MacGiro 13.pkg
2024-07-09 09:28:21 : DEBUG : macgiro13 : File list: -rw-r--r--  1 root  staff    55M  9 Jul 09:28 MacGiro 13.pkg
2024-07-09 09:28:21 : DEBUG : macgiro13 : File type: MacGiro 13.pkg: xar archive compressed TOC: 4689, SHA-1 checksum
2024-07-09 09:28:21 : DEBUG : macgiro13 : spctlOut is MacGiro 13.pkg: accepted
2024-07-09 09:28:21 : DEBUG : macgiro13 : source=Notarized Developer ID
2024-07-09 09:28:21 : DEBUG : macgiro13 : origin=Developer ID Installer: med-i-bit GmbH (G458QMSYRT)
2024-07-09 09:28:21 : INFO  : macgiro13 : Team ID: G458QMSYRT (expected: G458QMSYRT )
2024-07-09 09:28:21 : DEBUG : macgiro13 : DEBUG enabled, skipping installation
2024-07-09 09:28:21 : INFO  : macgiro13 : Finishing...
2024-07-09 09:28:24 : INFO  : macgiro13 : name: MacGiro 13, appName: MacGiro 13.app
2024-07-09 09:28:24.578 mdfind[12400:2310012] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2024-07-09 09:28:24.578 mdfind[12400:2310012] [UserQueryParser] Loading keywords and predicates for locale "de"
2024-07-09 09:28:24.639 mdfind[12400:2310012] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-09 09:28:24 : WARN  : macgiro13 : No previous app found
2024-07-09 09:28:24 : WARN  : macgiro13 : could not find MacGiro 13.app
2024-07-09 09:28:24 : REQ   : macgiro13 : Installed MacGiro 13
2024-07-09 09:28:24 : INFO  : macgiro13 : notifying
2024-07-09 09:28:25 : DEBUG : macgiro13 : DEBUG mode 1, not reopening anything
2024-07-09 09:28:25 : REQ   : macgiro13 : All done!
2024-07-09 09:28:25 : REQ   : macgiro13 : ################## End Installomator, exit code 0