### PR TITLE
Create sketchup2024.sh

### DIFF
--- a/fragments/labels/sketchup2024.sh
+++ b/fragments/labels/sketchup2024.sh
@@ -1,0 +1,10 @@
+sketchup2024)
+    name="SketchUp 2024"
+    type="dmg"
+    downloadURL="$(curl -s https://www.sketchup.com/en/download/all | grep -o 'https://download.sketchup.com/SketchUp-2024[^"]*.dmg')"
+    folderName="SketchUp 2024"
+    appName="${folderName}/SketchUp.app"
+    appNewVersion=$(echo "$downloadURL" | grep -o 'SketchUp-20[0-9][0-9]-[0-9]*-[0-9]*' | awk -F '-' '{year=substr($2, 3, 2); if (year >= 24) printf "%d.0.%s", year, $NF; else printf "%d.%s", year+2000, $NF}')
+    versionKey="CFBundleVersion"
+    expectedTeamID="J8PVMCY7KL"
+    ;;


### PR DESCRIPTION
2024-07-09 12:32:50 : REQ   : sketchup2024 : ################## Start Installomator v. 10.6beta, date 2024-07-09
2024-07-09 12:32:50 : INFO  : sketchup2024 : ################## Version: 10.6beta
2024-07-09 12:32:50 : INFO  : sketchup2024 : ################## Date: 2024-07-09
2024-07-09 12:32:50 : INFO  : sketchup2024 : ################## sketchup2024
2024-07-09 12:32:50 : DEBUG : sketchup2024 : DEBUG mode 1 enabled.
2024-07-09 12:32:51 : DEBUG : sketchup2024 : name=SketchUp 2024
2024-07-09 12:32:51 : DEBUG : sketchup2024 : appName=SketchUp 2024/SketchUp.app
2024-07-09 12:32:51 : DEBUG : sketchup2024 : type=dmg
2024-07-09 12:32:51 : DEBUG : sketchup2024 : archiveName=
2024-07-09 12:32:51 : DEBUG : sketchup2024 : downloadURL=https://download.sketchup.com/SketchUp-2024-0-554-221.dmg
2024-07-09 12:32:51 : DEBUG : sketchup2024 : curlOptions=
2024-07-09 12:32:51 : DEBUG : sketchup2024 : appNewVersion=24.0.554
2024-07-09 12:32:51 : DEBUG : sketchup2024 : appCustomVersion function: Not defined
2024-07-09 12:32:51 : DEBUG : sketchup2024 : versionKey=CFBundleVersion
2024-07-09 12:32:51 : DEBUG : sketchup2024 : packageID=
2024-07-09 12:32:51 : DEBUG : sketchup2024 : pkgName=
2024-07-09 12:32:51 : DEBUG : sketchup2024 : choiceChangesXML=
2024-07-09 12:32:51 : DEBUG : sketchup2024 : expectedTeamID=J8PVMCY7KL
2024-07-09 12:32:51 : DEBUG : sketchup2024 : blockingProcesses=
2024-07-09 12:32:51 : DEBUG : sketchup2024 : installerTool=
2024-07-09 12:32:51 : DEBUG : sketchup2024 : CLIInstaller=
2024-07-09 12:32:51 : DEBUG : sketchup2024 : CLIArguments=
2024-07-09 12:32:51 : DEBUG : sketchup2024 : updateTool=
2024-07-09 12:32:51 : DEBUG : sketchup2024 : updateToolArguments=
2024-07-09 12:32:51 : DEBUG : sketchup2024 : updateToolRunAsCurrentUser=
2024-07-09 12:32:51 : INFO  : sketchup2024 : BLOCKING_PROCESS_ACTION=tell_user
2024-07-09 12:32:51 : INFO  : sketchup2024 : NOTIFY=success
2024-07-09 12:32:51 : INFO  : sketchup2024 : LOGGING=DEBUG
2024-07-09 12:32:51 : INFO  : sketchup2024 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-09 12:32:51 : INFO  : sketchup2024 : Label type: dmg
2024-07-09 12:32:51 : INFO  : sketchup2024 : archiveName: SketchUp 2024.dmg
2024-07-09 12:32:51 : INFO  : sketchup2024 : no blocking processes defined, using SketchUp 2024 as default
2024-07-09 12:32:51 : DEBUG : sketchup2024 : Changing directory to .
2024-07-09 12:32:51 : INFO  : sketchup2024 : name: SketchUp 2024, appName: SketchUp 2024/SketchUp.app
2024-07-09 12:32:51.736 mdfind[24954:2600703] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2024-07-09 12:32:51.736 mdfind[24954:2600703] [UserQueryParser] Loading keywords and predicates for locale "de"
2024-07-09 12:32:51.899 mdfind[24954:2600703] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-09 12:32:52 : WARN  : sketchup2024 : No previous app found
2024-07-09 12:32:52 : WARN  : sketchup2024 : could not find SketchUp 2024/SketchUp.app
2024-07-09 12:32:52 : INFO  : sketchup2024 : appversion:
2024-07-09 12:32:52 : INFO  : sketchup2024 : Latest version of SketchUp 2024 is 24.0.554
2024-07-09 12:32:52 : REQ   : sketchup2024 : Downloading https://download.sketchup.com/SketchUp-2024-0-554-221.dmg to SketchUp 2024.dmg
2024-07-09 12:32:52 : DEBUG : sketchup2024 : No Dialog connection, just download
2024-07-09 12:33:01 : DEBUG : sketchup2024 : File list: -rw-r--r--  1 root  staff   987M  9 Jul 12:33 SketchUp 2024.dmg
2024-07-09 12:33:01 : DEBUG : sketchup2024 : File type: SketchUp 2024.dmg: bzip2 compressed data, block size = 100k
2024-07-09 12:33:01 : DEBUG : sketchup2024 : curl output was:
* Host download.sketchup.com:443 was resolved.
* IPv6: (none)
* IPv4: 18.239.83.82, 18.239.83.117, 18.239.83.16, 18.239.83.112
*   Trying 18.239.83.82:443...
* Connected to download.sketchup.com (18.239.83.82) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4952 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.sketchup.com
*  start date: Feb 11 00:00:00 2024 GMT
*  expire date: Mar 12 23:59:59 2025 GMT
*  subjectAltName: host "download.sketchup.com" matched cert's "*.sketchup.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.sketchup.com/SketchUp-2024-0-554-221.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.sketchup.com]
* [HTTP/2] [1] [:path: /SketchUp-2024-0-554-221.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /SketchUp-2024-0-554-221.dmg HTTP/2
> Host: download.sketchup.com
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 200
< content-type: binary/octet-stream
< content-length: 1034429823
< last-modified: Mon, 13 May 2024 15:02:29 GMT
< x-amz-server-side-encryption: AES256
< x-amz-version-id: cMSySD4pJVN_xA3sP2JHx6QavVY4v1K1 < accept-ranges: bytes
< server: AmazonS3
< date: Mon, 08 Jul 2024 15:57:31 GMT
< etag: "8b27dda25a8207e4caeb8c5a1db725af"
< vary: Accept-Encoding
< x-cache: Hit from cloudfront
< via: 1.1 416dae0837568c2bb7cea7ae5c6bba22.cloudfront.net (CloudFront) < x-amz-cf-pop: AMS58-P5
< x-amz-cf-id: z0wAcrhUaQArNBX7YBwX6vOEZ5OB154rB7xNf78kCJPgEQeCfFJaeA== < age: 66922
<
{ [16384 bytes data]
* Connection #0 to host download.sketchup.com left intact

2024-07-09 12:33:01 : DEBUG : sketchup2024 : DEBUG mode 1, not checking for blocking processes
2024-07-09 12:33:01 : REQ   : sketchup2024 : Installing SketchUp 2024
2024-07-09 12:33:01 : INFO  : sketchup2024 : Mounting ./SketchUp 2024.dmg
2024-07-09 12:33:55 : DEBUG : sketchup2024 : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $88DE347C
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $0B38662E
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $C896E5ED
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4) berechnen …
EFI System Partition (C12A7328-F81F-: Die überprüfte CRC32-Prüfsumme ist $B54B659C
Prüfsumme für disk image (Apple_HFS : 5) berechnen …
disk image (Apple_HFS : 5): Die überprüfte CRC32-Prüfsumme ist $630ED70E
Prüfsumme für  (Apple_Free : 6) berechnen …
(Apple_Free : 6): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 7) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $C896E5ED
Prüfsumme für GPT Header (Backup GPT Header : 8) berechnen …
GPT Header (Backup GPT Header : 8): Die überprüfte CRC32-Prüfsumme ist $B32C5A5A
Die überprüfte CRC32-Prüfsumme ist $E4DBCE9D
/dev/disk4              GUID_partition_scheme
/dev/disk4s1            EFI
/dev/disk4s2            Apple_HFS                       /Volumes/SketchUp 2024

2024-07-09 12:33:55 : INFO  : sketchup2024 : Mounted: /Volumes/SketchUp 2024 2024-07-09 12:33:55 : INFO  : sketchup2024 : Verifying: /Volumes/SketchUp 2024/SketchUp 2024/SketchUp.app
2024-07-09 12:33:55 : DEBUG : sketchup2024 : App size: 1,4G     /Volumes/SketchUp 2024/SketchUp 2024/SketchUp.app
2024-07-09 12:35:15 : DEBUG : sketchup2024 : Debugging enabled, App Verification output was:
/Volumes/SketchUp 2024/SketchUp 2024/SketchUp.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Trimble Inc. (J8PVMCY7KL)

2024-07-09 12:35:15 : INFO  : sketchup2024 : Team ID matching: J8PVMCY7KL (expected: J8PVMCY7KL ) 2024-07-09 12:35:15 : INFO  : sketchup2024 : Installing SketchUp 2024 version 24.0.554 on versionKey CFBundleVersion. 2024-07-09 12:35:15 : INFO  : sketchup2024 : App has LSMinimumSystemVersion: 11.7 2024-07-09 12:35:15 : DEBUG : sketchup2024 : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2024-07-09 12:35:15 : INFO  : sketchup2024 : Finishing... 2024-07-09 12:35:18 : INFO  : sketchup2024 : name: SketchUp 2024, appName: SketchUp 2024/SketchUp.app 2024-07-09 12:35:18.901 mdfind[25222:2605213] [UserQueryParser] Loading keywords and predicates for locale "de_DE" 2024-07-09 12:35:18.902 mdfind[25222:2605213] [UserQueryParser] Loading keywords and predicates for locale "de" 2024-07-09 12:35:18.985 mdfind[25222:2605213] Couldn't determine the mapping between prefab keywords and predicates. 2024-07-09 12:35:19 : WARN  : sketchup2024 : No previous app found 2024-07-09 12:35:19 : WARN  : sketchup2024 : could not find SketchUp 2024/SketchUp.app
2024-07-09 12:35:19 : REQ   : sketchup2024 : Installed SketchUp 2024, version 24.0.554
2024-07-09 12:35:19 : INFO  : sketchup2024 : notifying
2024-07-09 12:35:19 : DEBUG : sketchup2024 : Unmounting /Volumes/SketchUp 2024
2024-07-09 12:35:19 : DEBUG : sketchup2024 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-07-09 12:35:19 : DEBUG : sketchup2024 : DEBUG mode 1, not reopening anything
2024-07-09 12:35:19 : REQ   : sketchup2024 : All done!
2024-07-09 12:35:19 : REQ   : sketchup2024 : ################## End Installomator, exit code 0