### PR TITLE
Create starface90x.sh

### DIFF
--- a/fragments/labels/starface90x.sh
+++ b/fragments/labels/starface90x.sh
@@ -1,0 +1,9 @@
+starface90x)
+    name="STARFACE"
+    # Downloads the latest 9.0.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation
+    type="dmg"
+    downloadURL=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9.0" | cut -d '"' -f 10)
+    appNewVersion=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9.0" | cut -d '"' -f 4)
+    expectedTeamID="Q965D3UXEW"
+    versionKey="CFBundleVersion"
+    ;;


### PR DESCRIPTION
2024-11-14 18:07:29 : REQ   : starface90x : ################## Start Installomator v. 10.7beta, date 2024-11-14
2024-11-14 18:07:29 : INFO  : starface90x : ################## Version: 10.7beta
2024-11-14 18:07:29 : INFO  : starface90x : ################## Date: 2024-11-14
2024-11-14 18:07:29 : INFO  : starface90x : ################## starface90x
2024-11-14 18:07:29 : DEBUG : starface90x : DEBUG mode 1 enabled.
2024-11-14 18:07:30 : DEBUG : starface90x : name=STARFACE
2024-11-14 18:07:30 : DEBUG : starface90x : appName=
2024-11-14 18:07:31 : DEBUG : starface90x : type=dmg
2024-11-14 18:07:31 : DEBUG : starface90x : archiveName=
2024-11-14 18:07:31 : DEBUG : starface90x : downloadURL=https://www.starface-cdn.de/starface/clients/mac/STARFACE_9.0.0_1123_3426c5f.dmg
2024-11-14 18:07:31 : DEBUG : starface90x : curlOptions=
2024-11-14 18:07:31 : DEBUG : starface90x : appNewVersion=9.0.0
2024-11-14 18:07:31 : DEBUG : starface90x : appCustomVersion function: Not defined
2024-11-14 18:07:31 : DEBUG : starface90x : versionKey=CFBundleVersion
2024-11-14 18:07:31 : DEBUG : starface90x : packageID=
2024-11-14 18:07:31 : DEBUG : starface90x : pkgName=
2024-11-14 18:07:31 : DEBUG : starface90x : choiceChangesXML=
2024-11-14 18:07:31 : DEBUG : starface90x : expectedTeamID=Q965D3UXEW
2024-11-14 18:07:31 : DEBUG : starface90x : blockingProcesses=
2024-11-14 18:07:31 : DEBUG : starface90x : installerTool=
2024-11-14 18:07:31 : DEBUG : starface90x : CLIInstaller=
2024-11-14 18:07:31 : DEBUG : starface90x : CLIArguments=
2024-11-14 18:07:31 : DEBUG : starface90x : updateTool=
2024-11-14 18:07:31 : DEBUG : starface90x : updateToolArguments=
2024-11-14 18:07:31 : DEBUG : starface90x : updateToolRunAsCurrentUser=
2024-11-14 18:07:31 : INFO  : starface90x : BLOCKING_PROCESS_ACTION=tell_user
2024-11-14 18:07:31 : INFO  : starface90x : NOTIFY=success
2024-11-14 18:07:31 : INFO  : starface90x : LOGGING=DEBUG
2024-11-14 18:07:31 : INFO  : starface90x : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-11-14 18:07:31 : INFO  : starface90x : Label type: dmg
2024-11-14 18:07:31 : INFO  : starface90x : archiveName: STARFACE.dmg
2024-11-14 18:07:31 : INFO  : starface90x : no blocking processes defined, using STARFACE as default
2024-11-14 18:07:31 : DEBUG : starface90x : Changing directory to .
2024-11-14 18:07:31 : INFO  : starface90x : App(s) found: /Applications/STARFACE.app
2024-11-14 18:07:31 : INFO  : starface90x : found app at /Applications/STARFACE.app, version 1069, on versionKey CFBundleVersion
2024-11-14 18:07:31 : INFO  : starface90x : appversion: 1069
2024-11-14 18:07:31 : INFO  : starface90x : Latest version of STARFACE is 9.0.0
2024-11-14 18:07:31 : REQ   : starface90x : Downloading https://www.starface-cdn.de/starface/clients/mac/STARFACE_9.0.0_1123_3426c5f.dmg to STARFACE.dmg
2024-11-14 18:07:31 : DEBUG : starface90x : No Dialog connection, just download
2024-11-14 18:08:46 : DEBUG : starface90x : File list: -rw-r--r--@ 1 root  staff   197M 14 Nov 18:08 STARFACE.dmg
2024-11-14 18:08:46 : DEBUG : starface90x : File type: STARFACE.dmg: zlib compressed data
2024-11-14 18:08:47 : DEBUG : starface90x : curl output was:
* Host www.starface-cdn.de:443 was resolved.
* IPv6: 2001:8d8:100f:f000::220
* IPv4: 217.160.0.241
*   Trying [2001:8d8:100f:f000::220]:443...
* Connected to www.starface-cdn.de (2001:8d8:100f:f000::220) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [70 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4589 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.starface-cdn.de
*  start date: Oct  3 00:00:00 2024 GMT
*  expire date: Oct 17 23:59:59 2025 GMT
*  subjectAltName: host "www.starface-cdn.de" matched cert's "*.starface-cdn.de"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.starface-cdn.de/starface/clients/mac/STARFACE_9.0.0_1123_3426c5f.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.starface-cdn.de]
* [HTTP/2] [1] [:path: /starface/clients/mac/STARFACE_9.0.0_1123_3426c5f.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /starface/clients/mac/STARFACE_9.0.0_1123_3426c5f.dmg HTTP/2
> Host: www.starface-cdn.de
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 200
< content-type: application/x-apple-diskimage
< content-length: 206897807
< date: Thu, 14 Nov 2024 17:07:31 GMT
< server: Apache
< last-modified: Fri, 18 Oct 2024 12:56:07 GMT
< etag: "c55028f-624bfd38f47c0"
< accept-ranges: bytes
<
{ [8192 bytes data]
* Connection #0 to host www.starface-cdn.de left intact

2024-11-14 18:08:47 : DEBUG : starface90x : DEBUG mode 1, not checking for blocking processes
2024-11-14 18:08:47 : REQ   : starface90x : Installing STARFACE
2024-11-14 18:08:47 : INFO  : starface90x : Mounting ./STARFACE.dmg
2024-11-14 18:08:49 : DEBUG : starface90x : Debugging enabled, dmgmount output was:
Prüfsumme für Driver Descriptor Map (DDM : 0) berechnen …
Driver Descriptor Map (DDM : 0): Die überprüfte CRC32-Prüfsumme ist $5CB634E0
Prüfsumme für Apple (Apple_partition_map : 1) berechnen …
Apple (Apple_partition_map : 1): Die überprüfte CRC32-Prüfsumme ist $C10D3303
Prüfsumme für DiscRecording 9.0.3d5 (Apple_HFS : 2) berechnen …
DiscRecording 9.0.3d5 (Apple_HFS : 2: Die überprüfte CRC32-Prüfsumme ist $FFE569C4
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Die überprüfte CRC32-Prüfsumme ist $C198A2DE
/dev/disk11             Apple_partition_scheme
/dev/disk11s1           Apple_partition_map
/dev/disk11s2           Apple_HFS                       /Volumes/STARFACE Installer

2024-11-14 18:08:49 : INFO  : starface90x : Mounted: /Volumes/STARFACE Installer 2024-11-14 18:08:49 : INFO  : starface90x : Verifying: /Volumes/STARFACE Installer/STARFACE.app
2024-11-14 18:08:49 : DEBUG : starface90x : App size: 473M      /Volumes/STARFACE Installer/STARFACE.app
2024-11-14 18:08:51 : DEBUG : starface90x : Debugging enabled, App Verification output was:
/Volumes/STARFACE Installer/STARFACE.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: STARFACE GmbH (Q965D3UXEW)

2024-11-14 18:08:51 : INFO  : starface90x : Team ID matching: Q965D3UXEW (expected: Q965D3UXEW ) 2024-11-14 18:08:51 : INFO  : starface90x : Downloaded version of STARFACE is 1123 on versionKey CFBundleVersion (replacing version 1069). 2024-11-14 18:08:51 : INFO  : starface90x : App has LSMinimumSystemVersion: 11.0 2024-11-14 18:08:51 : DEBUG : starface90x : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2024-11-14 18:08:51 : INFO  : starface90x : Finishing... 2024-11-14 18:08:54 : INFO  : starface90x : App(s) found: /Applications/STARFACE.app 2024-11-14 18:08:54 : INFO  : starface90x : found app at /Applications/STARFACE.app, version 1069, on versionKey CFBundleVersion
2024-11-14 18:08:54 : REQ   : starface90x : Installed STARFACE, version 1123
2024-11-14 18:08:54 : INFO  : starface90x : notifying
2024-11-14 18:08:54 : DEBUG : starface90x : Unmounting /Volumes/STARFACE Installer
2024-11-14 18:08:54 : DEBUG : starface90x : Debugging enabled, Unmounting output was:
"disk11" ejected.
2024-11-14 18:08:54 : DEBUG : starface90x : DEBUG mode 1, not reopening anything
2024-11-14 18:08:54 : REQ   : starface90x : All done!
2024-11-14 18:08:54 : REQ   : starface90x : ################## End Installomator, exit code 0