### PR TITLE
Update Starface 9 to include Subversions

### DIFF
--- a/fragments/labels/starface90x.sh
+++ b/fragments/labels/starface90x.sh
@@ -1,9 +1,0 @@
-starface90x)
-    name="STARFACE"
-    # Downloads the latest 9.0.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation
-    type="dmg"
-    downloadURL=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9.0" | cut -d '"' -f 10)
-    appNewVersion=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9.0" | cut -d '"' -f 4)
-    expectedTeamID="Q965D3UXEW"
-    versionKey="CFBundleVersion"
-    ;;

--- a/fragments/labels/starface9x.sh
+++ b/fragments/labels/starface9x.sh
@@ -1,0 +1,9 @@
+starface9x)
+    name="STARFACE"
+    # Downloads the latest 9.0.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation
+    type="dmg"
+    downloadURL=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9" | cut -d '"' -f 10)
+    appNewVersion=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9" | cut -d '"' -f 4)
+    expectedTeamID="Q965D3UXEW"
+    versionKey="CFBundleVersion"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered Yes before submitting the pull request.
Have you confirmed this pull request is not a duplicate?
Yes

Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?
No

Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?
Yes

Additional context Add any other context about the label or fix here.
This Update allows the download and installation of Subversions of Starface 9.X

Installomator log At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. DEBUG=1 can be enabled but do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!

2025-06-30 12:53:07 : REQ   : starface9x : ################## Start Installomator v. 10.9beta, date 2025-06-30
2025-06-30 12:53:07 : INFO  : starface9x : ################## Version: 10.9beta
2025-06-30 12:53:07 : INFO  : starface9x : ################## Date: 2025-06-30
2025-06-30 12:53:07 : INFO  : starface9x : ################## starface9x
2025-06-30 12:53:07 : DEBUG : starface9x : DEBUG mode 1 enabled.
2025-06-30 12:53:08 : INFO  : starface9x : setting variable from argument LOGGING=INFO
2025-06-30 12:53:08 : INFO  : starface9x : BLOCKING_PROCESS_ACTION=tell_user
2025-06-30 12:53:08 : INFO  : starface9x : NOTIFY=success
2025-06-30 12:53:08 : INFO  : starface9x : LOGGING=INFO
2025-06-30 12:53:08 : INFO  : starface9x : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-06-30 12:53:08 : INFO  : starface9x : Label type: dmg
2025-06-30 12:53:08 : INFO  : starface9x : archiveName: STARFACE.dmg
2025-06-30 12:53:08 : INFO  : starface9x : no blocking processes defined, using STARFACE as default
2025-06-30 12:53:08 : INFO  : starface9x : App(s) found: /Applications/STARFACE.app
2025-06-30 12:53:08 : INFO  : starface9x : found app at /Applications/STARFACE.app, version 1181, on versionKey CFBundleVersion
2025-06-30 12:53:08 : INFO  : starface9x : appversion: 1181
2025-06-30 12:53:08 : INFO  : starface9x : Latest version of STARFACE is 9.1.0
2025-06-30 12:53:08 : INFO  : starface9x : STARFACE.dmg exists and DEBUG mode 1 enabled, skipping download
2025-06-30 12:53:08 : REQ   : starface9x : Installing STARFACE
2025-06-30 12:53:08 : INFO  : starface9x : Mounting ./STARFACE.dmg
2025-06-30 12:53:08 : INFO  : starface9x : Mounted: /Volumes/STARFACE Installer
2025-06-30 12:53:08 : INFO  : starface9x : Verifying: /Volumes/STARFACE Installer/STARFACE.app
2025-06-30 12:53:09 : INFO  : starface9x : Team ID matching: Q965D3UXEW (expected: Q965D3UXEW )
2025-06-30 12:53:09 : INFO  : starface9x : Downloaded version of STARFACE is 1297 on versionKey CFBundleVersion (replacing version 1181).
2025-06-30 12:53:09 : INFO  : starface9x : App has LSMinimumSystemVersion: 13.0
2025-06-30 12:53:10 : INFO  : starface9x : Finishing...
2025-06-30 12:53:13 : INFO  : starface9x : App(s) found: /Applications/STARFACE.app
2025-06-30 12:53:13 : INFO  : starface9x : found app at /Applications/STARFACE.app, version 1181, on versionKey CFBundleVersion
2025-06-30 12:53:13 : REQ   : starface9x : Installed STARFACE, version 1297
2025-06-30 12:53:13 : INFO  : starface9x : notifying
2025-06-30 12:53:13 : REQ   : starface9x : All done!
2025-06-30 12:53:13 : REQ   : starface9x : ################## End Installomator, exit code 0 
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")